### PR TITLE
Support SpiderMonkey Nightly builds

### DIFF
--- a/src/engines/spidermonkey.js
+++ b/src/engines/spidermonkey.js
@@ -61,8 +61,12 @@ class SpiderMonkeyInstaller extends Installer {
   }
 
   getDownloadURL(version) {
-    if (this.isLatest) {
-      return `https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/jsshell-${getFilename()}.zip`;
+    const match = /@(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})$/.exec(version);
+    if (match) {
+      const year = match[1];
+      const month = match[2];
+      const date = match.slice(1).join('-');
+      return `https://archive.mozilla.org/pub/firefox/nightly/${year}/${month}/${date}-mozilla-central/jsshell-${getFilename()}.zip`
     }
     return `https://archive.mozilla.org/pub/firefox/releases/${version}/jsshell/jsshell-${getFilename()}.zip`;
   }

--- a/src/engines/spidermonkey.js
+++ b/src/engines/spidermonkey.js
@@ -35,17 +35,17 @@ class SpiderMonkeyInstaller extends Installer {
       // Build a request for buildhub2: https://buildhub2.readthedocs.io/en/latest/project.html
       const body = {
         size: 1,
-        sort: {'build.id': 'desc'},
+        sort: { 'build.id': 'desc' },
         query: {
           bool: {
             must: [
-              {term: {'source.product': 'firefox'}},
-              {term: {'source.tree': 'mozilla-central'}},
-              {term: {'target.channel': 'nightly'}},
-              {term: {'target.platform': getFilename()}},
-            ]
-          }
-        }
+              { term: { 'source.product': 'firefox' } },
+              { term: { 'source.tree': 'mozilla-central' } },
+              { term: { 'target.channel': 'nightly' } },
+              { term: { 'target.platform': getFilename() } },
+            ],
+          },
+        },
       };
 
       const data = await fetch('https://buildhub.moz.tools/api/search', {
@@ -66,7 +66,7 @@ class SpiderMonkeyInstaller extends Installer {
       const year = match[1];
       const month = match[2];
       const date = match.slice(1).join('-');
-      return `https://archive.mozilla.org/pub/firefox/nightly/${year}/${month}/${date}-mozilla-central/jsshell-${getFilename()}.zip`
+      return `https://archive.mozilla.org/pub/firefox/nightly/${year}/${month}/${date}-mozilla-central/jsshell-${getFilename()}.zip`;
     }
     return `https://archive.mozilla.org/pub/firefox/releases/${version}/jsshell/jsshell-${getFilename()}.zip`;
   }

--- a/src/engines/spidermonkey.js
+++ b/src/engines/spidermonkey.js
@@ -55,13 +55,13 @@ class SpiderMonkeyInstaller extends Installer {
 
       const source = data.hits.hits[0]._source;
 
-      return `${source.target.version}@${source.build.id}`;
+      return `${source.target.version}#${source.build.id}`;
     }
     return version;
   }
 
   getDownloadURL(version) {
-    const match = /@(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})$/.exec(version);
+    const match = /#(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})$/.exec(version);
     if (match) {
       const year = match[1];
       const month = match[2];


### PR DESCRIPTION
Previously when requesting "latest" for SpiderMonkey, only the latest
available Beta version of SpiderMonkey was installed. Using the buildhub2 API
we can determine the latest Nightly version. Nightly binaries are available
under "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central".