### PR TITLE
Accommodate recent change to JSC's print utility

### DIFF
--- a/src/engines/javascriptcore.js
+++ b/src/engines/javascriptcore.js
@@ -114,11 +114,12 @@ class JavaScriptCoreInstaller extends Installer {
 
   async test() {
     const program = 'print("42");';
-    const output = '42';
+    const output = (await execa(this.binPath, ['-e', program])).stdout;
+    const pattern = /^("?)42\1$/;
 
-    assert.strictEqual(
-      (await execa(this.binPath, ['-e', program])).stdout,
-      output,
+    assert(
+      pattern.test(output),
+      `Expected string "${output}" to match pattern ${pattern}`,
     );
   }
 }


### PR DESCRIPTION
On 2021-09-29, the `print` function in JavaScriptCore was modified to
display string values within quotation mark characters [1]. This
interfered with esvu's ability to install the engine, failing with
an error, e.g.

    JavaScriptCore ❯ Testing...
    esvu ✖ Fatal error installing JavaScriptCore AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:

    '"42"' !== '42'

Update the installation script to accept both this behavior and the
prior behavior in order to preserve functionality when installing old
versions of the engine.

[1] https://bugs.webkit.org/show_bug.cgi?id=230931

---

As far as I know, the JSC project hosts builds for a very limited time. If that's right, then it might not be necessary to support both versions of the expected output. If we *do* want to use a regular expression, Node.js also provides `assert.match`, but I left that out since it's not considered "stable" in Node's LTS release.

/cc @rwaldron (this is what's causing failures in Test262's CI environment)