### PR TITLE
Use GraalJS standalone when installing graaljs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,18 +34,18 @@ selected.
 If you're using [eshost-cli][], you can run `eshost --configure-esvu` after
 installing engines to make eshost automatically find the installed engines.
 
-| Engine             | Binary Names                     | `darwin-x64` | `darwin-arm64` | `linux-ia32` | `linux-x64` | `win32-ia32` | `win32-x64` |
-| ------------------ | -------------------------------- | ------------ | -------------- | ------------ | ----------- | ------------ | ----------- |
-| [Chakra][]         | `ch`, `chakra`                   | ✅           |                |              | ✅          | ✅           | ✅          |
-| [engine262][]      | `engine262`                      | ✅           | ✅             | ✅           | ✅          | ✅           | ✅          |
-| [GraalJS][]        | `graaljs`                        | ✅           |                |              | ✅          |              | ✅          |
-| [Hermes][]         | `hermes`                         | ✅           |                |              |             |              | ✅          |
-| [LibJS][]          | `serenity-js`                    |              |                |              | ✅          |              |             |
-| [JavaScriptCore][] | `jsc`, `javascriptcore`          | ✅           | ✅             |              | ✅          |              | ✅          |
-| [QuickJS][]        | `quickjs`, `quickjs-run-test262` | ✅           |                | ✅           | ✅          | ✅           | ✅          |
-| [SpiderMonkey][]   | `sm`, `spidermonkey`             | ✅           | ✅             | ✅           | ✅          | ✅           | ✅          |
-| [V8][]             | `v8`                             | ✅           | ✅             | ✅           | ✅          | ✅           | ✅          |
-| [XS][]             | `xs`                             | ✅           |                | ✅           | ✅          |              | ✅          |
+| Engine             | Binary Names                     | `darwin-x64` | `darwin-arm64` | `linux-ia32` | `linux-x64` | `linux-arm64` | `win32-ia32` | `win32-x64` |
+| ------------------ | -------------------------------- | ------------ | -------------- | ------------ | ----------- | ------------- | ------------ | ----------- |
+| [Chakra][]         | `ch`, `chakra`                   | ✅           |                |              | ✅          |               | ✅           | ✅          |
+| [engine262][]      | `engine262`                      | ✅           | ✅             | ✅           | ✅          | ✅            | ✅           | ✅          |
+| [GraalJS][]        | `graaljs`                        | ✅           | ✅             |              | ✅          | ✅            |              | ✅          |
+| [Hermes][]         | `hermes`                         | ✅           |                |              |             |               |              | ✅          |
+| [LibJS][]          | `serenity-js`                    |              |                |              | ✅          |               |              |             |
+| [JavaScriptCore][] | `jsc`, `javascriptcore`          | ✅           | ✅             |              | ✅          |               |              | ✅          |
+| [QuickJS][]        | `quickjs`, `quickjs-run-test262` | ✅           |                | ✅           | ✅          |               | ✅           | ✅          |
+| [SpiderMonkey][]   | `sm`, `spidermonkey`             | ✅           | ✅             | ✅           | ✅          |               | ✅           | ✅          |
+| [V8][]             | `v8`                             | ✅           | ✅             | ✅           | ✅          |               | ✅           | ✅          |
+| [XS][]             | `xs`                             | ✅           |                | ✅           | ✅          |               |              | ✅          |
 
 Some binaries may be exposed as batch/shell scripts to properly handling shared library loading. Some binaries on
 64-bit systems may be natively 32-bit.

--- a/src/engines/chakra.js
+++ b/src/engines/chakra.js
@@ -83,7 +83,7 @@ class ChakraInstaller extends Installer {
 ChakraInstaller.config = {
   name: 'Chakra',
   id: 'ch',
-  supports: ['linux-x64', 'darwin-x64', 'win32-ia32', 'win32-x64'],
+  supported: ['linux-x64', 'darwin-x64', 'win32-ia32', 'win32-x64'],
 };
 
 module.exports = ChakraInstaller;

--- a/src/engines/graaljs.js
+++ b/src/engines/graaljs.js
@@ -34,11 +34,6 @@ class GraalJSInstaller extends Installer {
     this.binPath = undefined;
   }
 
-  static shouldInstallByDefault() {
-    // Graal VM archives are >400mb, so don't download by default.
-    return false;
-  }
-
   static async resolveVersion(version) {
     if (version === 'latest') {
       const body = await fetch('https://api.github.com/repos/oracle/graaljs/releases')

--- a/src/engines/graaljs.js
+++ b/src/engines/graaljs.js
@@ -9,7 +9,7 @@ const { platform, untar, unzip } = require('../common');
 function getFilename() {
   switch (platform) {
     case 'darwin-x64':
-      return 'darwin-amd64';
+      return 'macos-amd64';
     case 'linux-x64':
       return 'linux-amd64';
     case 'win32-x64':
@@ -37,7 +37,7 @@ class GraalJSInstaller extends Installer {
 
   static async resolveVersion(version) {
     if (version === 'latest') {
-      const body = await fetch('https://api.github.com/repos/graalvm/graalvm-ce-builds/releases')
+      const body = await fetch('https://api.github.com/repos/oracle/graaljs/releases')
         .then((r) => r.json());
       return body
         .filter((b) => !b.prerelease)
@@ -48,7 +48,7 @@ class GraalJSInstaller extends Installer {
   }
 
   async getDownloadURL(version) {
-    return `https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/graalvm-ce-java11-${getFilename()}-${version}${getArchiveExtension()}`;
+    return `https://github.com/oracle/graaljs/releases/download/vm-${version}/graaljs-${version}-${getFilename()}${getArchiveExtension()}`;
   }
 
   async extract() {
@@ -60,20 +60,19 @@ class GraalJSInstaller extends Installer {
   }
 
   async install() {
-    const root = `graalvm-ce-java11-${this.version}`;
+    const root = `graaljs-${this.version}-${getFilename()}`;
+    let graaljs;
     if (platform === 'darwin-x64') {
-      await this.registerAsset(`${root}/Contents/Home/languages/js/graaljs.jar`);
-      await this.registerAsset(`${root}/Contents/Home/languages/js/lib/libjsvm.dylib`);
-      this.binPath = await this.registerBinary(`${root}/Contents/Home/languages/js/bin/js`, 'graaljs');
+      await this.registerAsset(`${root}/Contents/Home/lib/libjsvm.dylib`);
+      graaljs = await this.registerAsset(`${root}/Contents/Home/bin/js`);
     } else if (platform === 'win32-x64') {
-      await this.registerAsset(`${root}/languages/js/graaljs.jar`);
-      await this.registerAsset(`${root}/languages/js/lib/jsvm.dll`);
-      this.binPath = await this.registerBinary(`${root}/languages/js/bin/js.exe`, 'graaljs.exe');
+      await this.registerAsset(`${root}/lib/jsvm.dll`);
+      graaljs = await this.registerAsset(`${root}/bin/js.exe`);
     } else {
-      await this.registerAsset(`${root}/languages/js/graaljs.jar`);
-      await this.registerAsset(`${root}/languages/js/lib/libjsvm.so`);
-      this.binPath = await this.registerBinary(`${root}/languages/js/bin/js`, 'graaljs');
+      await this.registerAsset(`${root}/lib/libjsvm.so`);
+      graaljs = await this.registerAsset(`${root}/bin/js`);
     }
+    this.binPath = await this.registerScript('graaljs', `${graaljs}`);
   }
 
   async test() {

--- a/src/engines/graaljs.js
+++ b/src/engines/graaljs.js
@@ -14,6 +14,10 @@ function getFilename() {
       return 'linux-amd64';
     case 'win32-x64':
       return 'windows-amd64';
+    case 'darwin-arm64':
+      return 'macos-aarch64';
+    case 'linux-arm64':
+      return 'linux-aarch64';
     default:
       throw new Error(`No GraalJS builds available for ${platform}`);
   }
@@ -90,7 +94,7 @@ GraalJSInstaller.config = {
   name: 'GraalJS',
   id: 'graaljs',
   supported: [
-    'linux-x64', 'win32-x64', 'darwin-x64',
+    'linux-x64', 'win32-x64', 'darwin-x64', 'linux-arm64', 'darwin-arm64',
   ],
 };
 


### PR DESCRIPTION
The installer used GraalVM CE download before. This was possible because `graaljs` was its prominent component that was always installed. This is going to change. It will be an optional component (like other languages) that is not installed by default. So, this PR modifies the installer to use the standalone release of GraalJS. The additional benefit is that the download size of the standalone release is much smaller than the size of GraalVM CE.