### PR TITLE
Use win64 for SpiderMonkey buildhub queries regardless of platform (#39)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esvu",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "",
   "main": "src/index.js",
   "dependencies": {

--- a/src/engines/spidermonkey.js
+++ b/src/engines/spidermonkey.js
@@ -43,7 +43,7 @@ class SpiderMonkeyInstaller extends Installer {
               { term: { 'source.product': 'firefox' } },
               { term: { 'source.tree': 'mozilla-central' } },
               { term: { 'target.channel': 'nightly' } },
-              { term: { 'target.platform': getFilename() } },
+              { term: { 'target.platform': 'win64' } }, // Set 'win64' because buildhub only lists win* builds
             ],
           },
         },


### PR DESCRIPTION
Fix that would let non-win platforms keep up with nightlies. I couldn't find moz-hosted linux, mac, etc build data at any other service's API endpoint (e.g. pollbot, product-details), but perhaps a mozillian could point in a better direction for this if buildhub isn't it.