### PR TITLE
Add support for macOS builds of LibJs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ installing engines to make eshost automatically find the installed engines.
 | [engine262][]      | `engine262`                      | ✅           | ✅             | ✅           | ✅          | ✅            | ✅           | ✅          |
 | [GraalJS][]        | `graaljs`                        | ✅           | ✅             |              | ✅          | ✅            |              | ✅          |
 | [Hermes][]         | `hermes`                         | ✅           |                |              |             |               |              | ✅          |
-| [LibJS][]          | `serenity-js`                    |              |                |              | ✅          |               |              |             |
+| [LibJS][]          | `serenity-js`                    | ✅           | ✅             |              | ✅          |               |              |             |
 | [JavaScriptCore][] | `jsc`, `javascriptcore`          | ✅           | ✅             |              | ✅          |               |              | ✅          |
 | [QuickJS][]        | `quickjs`, `quickjs-run-test262` | ✅           |                | ✅           | ✅          |               | ✅           | ✅          |
 | [SpiderMonkey][]   | `sm`, `spidermonkey`             | ✅           | ✅             | ✅           | ✅          |               | ✅           | ✅          |


### PR DESCRIPTION
SerenityOS has added a new CI workflow for libjs binary builds, so use the new workflow to download binary artifacts for macOS and Linux.

~~This will not work properly until https://github.com/SerenityOS/serenity/pull/16274 is merged.~~
The serenity PR accompanying this is now merged, so this PR will be required to get the latest artifacts for LibJS. 

e.g.: https://github.com/SerenityOS/serenity/actions/runs/3608852279


@linusg mentioned that @ljharb had requested this recently :^)