### PR TITLE
XS binaries moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ installing engines to make eshost automatically find the installed engines.
 | [QuickJS][]        | `quickjs`, `quickjs-run-test262` | ✅           |                | ✅           | ✅          |               | ✅           | ✅          |
 | [SpiderMonkey][]   | `sm`, `spidermonkey`             | ✅           | ✅             | ✅           | ✅          |               | ✅           | ✅          |
 | [V8][]             | `v8`                             | ✅           | ✅             | ✅           | ✅          |               | ✅           | ✅          |
-| [XS][]             | `xs`                             | ✅           |                | ✅           | ✅          |               |              | ✅          |
+| [XS][]             | `xs`                             | ✅           | ✅             |              | ✅          | ✅            |              | ✅          |
 
 Some binaries may be exposed as batch/shell scripts to properly handling shared library loading. Some binaries on
 64-bit systems may be natively 32-bit.

--- a/src/engines/xs.js
+++ b/src/engines/xs.js
@@ -9,15 +9,14 @@ const { platform, unzip } = require('../common');
 function getFilename(version) {
   switch (platform) {
     case 'darwin-x64':
-      return 'mac';
-    case 'linux-ia32':
-      return 'lin32';
+      return 'mac64';
+    case 'darwin-arm64':
+      return 'mac64arm';
     case 'linux-x64':
       return 'lin64';
+    case 'linux-arm64':
+      return 'lin64arm';
     case 'win32-x64':
-      if (parseInt(version, 10) < 11) {
-        return 'win';
-      }
       return 'win64';
     default:
       throw new Error(`No XS builds available for ${platform}`);
@@ -33,15 +32,14 @@ class XSInstaller extends Installer {
 
   static async resolveVersion(version) {
     if (version === 'latest') {
-      const body = await fetch('https://api.github.com/repos/Moddable-OpenSource/moddable-xst/releases')
+      const body = await fetch('https://api.github.com/repos/Moddable-OpenSource/moddable/releases')
         .then((r) => r.json());
-      return body.find((b) => !b.prerelease).tag_name.slice(1);
+      return body.find((b) => !b.prerelease).tag_name;
     }
     return version;
   }
-
   getDownloadURL(version) {
-    return `https://github.com/Moddable-OpenSource/moddable-xst/releases/download/v${version}/xst-${getFilename(version)}.zip`;
+    return `https://github.com/Moddable-OpenSource/moddable/releases/download/${version}/xst-${getFilename(version)}.zip`;
   }
 
   extract() {
@@ -72,9 +70,9 @@ XSInstaller.config = {
   name: 'XS',
   id: 'xs',
   supported: [
-    'linux-ia32', 'linux-x64',
+    'linux-arm64', 'linux-x64',
     'win32-x64',
-    'darwin-x64',
+    'darwin-arm64', 'darwin-x64',
   ],
 };
 

--- a/src/engines/xs.js
+++ b/src/engines/xs.js
@@ -6,7 +6,7 @@ const execa = require('execa');
 const Installer = require('../installer');
 const { platform, unzip } = require('../common');
 
-function getFilename(version) {
+function getFilename() {
   switch (platform) {
     case 'darwin-x64':
       return 'mac64';


### PR DESCRIPTION
XS binaries moved to the main Moddable Open Source repo.
The supported platforms are darwin-x64, darwin-arm64, linux-x64, linux-arm64 and win32-x64.
This commit updates the readme and xs.js.
Thank you!