### PR TITLE
fix: improve error message for unknown macOS version

### DIFF
--- a/src/engines/javascriptcore.js
+++ b/src/engines/javascriptcore.js
@@ -33,7 +33,8 @@ async function getVersionFromBuilder(builder) {
 }
 
 async function getMacBuilder() {
-  switch (await macName()) {
+  const name = await macName();
+  switch (name) {
     case 'ventura':
       return 706;
     case 'monterey':
@@ -41,7 +42,7 @@ async function getMacBuilder() {
     case 'sonoma':
       return 938;
     default:
-      throw new Error(`Unknown macOS release: ${macName()}`);
+      throw new Error(`Unknown macOS release: ${name}. If it's a new version, consider making a pull request to https://github.com/devsnek/esvu.`);
   }
 }
 


### PR DESCRIPTION
Sonoma support has been added, but the error message for it previously was quite cryptic:

```
JavaScriptCore ❯ Checking version...
esvu ✖ Fatal error installing JavaScriptCore Error: Unknown macOS release: [object Promise]
```

This fixes the message and also added some actionable text.