### PR TITLE
Fix usage of `inquirer`'s `prompt`

### DIFF
--- a/src/bin.js
+++ b/src/bin.js
@@ -66,7 +66,7 @@ async function loadStatus(promptIfEmpty) {
   }
 
   if (status.selectedEngines.length === 0 && promptIfEmpty) {
-    const result = await inquirer.prompt({
+    const result = await inquirer.default.prompt({
       name: 'selectedEngines',
       type: 'checkbox',
       message: 'Select engines to install',


### PR DESCRIPTION
inquirer v13 only has a default export: https://npmx.dev/package-code/inquirer/v/13.4.2/dist%2Findex.js

However https://github.com/devsnek/esvu/blob/1daf878b3f52a65378b0ce4a67e815beddae7c4f/src/bin.js#L69 is trying to use a non-existing `prompt` export of it.